### PR TITLE
Add support for theme typing (Styled Components-like)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,10 @@ export { cssToRNStyle } from './cssToRN'
 export { SharedValue, FontSizeContext, RemContext } from './styleComponent'
 export * from './useTheme'
 
+export interface ISharedValue {}
+
+export interface DefaultTheme {}
+
 const styled = <T, >(Component: React.ComponentType<T>) => styledComponent<T>(Component)
 
 styled.ActivityIndicator = styled(RN.ActivityIndicator)

--- a/src/styleComponent.tsx
+++ b/src/styleComponent.tsx
@@ -7,6 +7,7 @@ import cssToStyle from './cssToRN'
 import { useFontSize, useHover, useLayout, useScreenSize, useMediaQuery } from './features'
 import type { Style, Units } from './types'
 import generateHash from './generateHash'
+import { DefaultTheme } from '.'
 
 export const defaultUnits: Units = { em: 16, vw: 1, vh: 1, vmin: 1, vmax: 1, rem: 16, px: 1, pt: 72 / 96, in: 96, pc: 9, cm: 96 / 2.54, mm: 96 / 25.4 }
 export const RemContext = React.createContext<number>(defaultUnits.rem)
@@ -16,7 +17,7 @@ export const FontSizeContext = React.createContext(defaultUnits.em)
 export const SharedValue = React.createContext<unknown>(undefined)
 
 type Primitive = number | string | null | undefined | boolean
-type Functs<T> = (arg: T & { rnCSS?: string; shared: unknown, theme: unknown }) => Primitive
+type Functs<T> = (arg: T & { rnCSS?: string; shared: unknown, theme: DefaultTheme }) => Primitive
 type OptionalProps = {
   rnCSS?: `${string};`;
   onMouseEnter?: (event: MouseEvent) => void;

--- a/src/useTheme.tsx
+++ b/src/useTheme.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { SharedValue } from './styleComponent'
+import { DefaultTheme } from '.';
 
 /** Provider for the theme. */
-export const ThemeProvider = ({ theme, children }: { theme: unknown; children: React.ReactNode }) => {
+export const ThemeProvider = ({ theme, children }: { theme: DefaultTheme; children: React.ReactNode }) => {
   return <SharedValue.Provider value={theme}>
     {children}
   </SharedValue.Provider>


### PR DESCRIPTION
Already tested locally and this implementation is working just fine.

```typescript
import 'rn-css';

import mainTheme from '../../ui/theme/main';

declare module 'rn-css' {
    type MainTheme = typeof mainTheme;

    export interface DefaultTheme extends MainTheme {}
}
```